### PR TITLE
fix `series()` to run in sequence

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,5 +97,5 @@ export async function parallel(list) {
  *	])
  */
 export async function series(list) {
-	return reduce(list, async (acc, v) => acc.concat(await v()), []);
+  return reduce(list, pushReducer, []);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -97,5 +97,5 @@ export async function parallel(list) {
  *	])
  */
 export async function series(list) {
-	return await reduce(resolve(list), pushReducer, []);
+	return list.reduce((acc, cur) => acc.then(cur), Promise.resolve());
 }

--- a/src/index.js
+++ b/src/index.js
@@ -97,5 +97,5 @@ export async function parallel(list) {
  *	])
  */
 export async function series(list) {
-	return list.reduce((acc, cur) => acc.then(cur), Promise.resolve());
+	return reduce(list, async (acc, v) => acc.concat(await v()), []);
 }

--- a/src/util.js
+++ b/src/util.js
@@ -12,6 +12,6 @@ export function resolve(list) {
  *	@private
  */
 export async function pushReducer(acc, v) {
-	acc.push(await v);
+  acc.push(await v());
 	return acc;
 }


### PR DESCRIPTION
Fixes #3 

I'm not able to build or run tests since I'm on Windows (separate discussion - consider using cross-platform npm scripts eventually?) so you'll want to confirm. I did run a quick test script of my own though, which was this:

```js
import { series } from './src'

let i = 0
const delayed = ms => {
  return new Promise(resolve =>
    setTimeout(() => (console.log(++i), resolve(i)), ms)
  )
}

series([
  () => delayed(1000),
  () => delayed(1000),
  () => delayed(1000),
  () => delayed(1000),
  () => delayed(1000)
]).then(res => {
  console.log('done', res)
})
```

You'll see the numbers 1-5 logged with about a second between each and then `'done' [1, 2, 3, 4, 5]`.