### PR TITLE
Fix `reduce()` accumulator type in JSDoc comment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { resolve, pushReducer } from './util';
  *
  *	@param {Array} array			The Array to reduce
  *	@param {Function} reducer		Async function, gets passed `(accumulator, value, index, array)` and returns a new value for `accumulator`
- *	@param {Any} [accumulator]		Optional initial accumulator value
+ *	@param {*} [accumulator]		Optional initial accumulator value
  *	@returns final `accumulator` value
  *
  *	@example


### PR DESCRIPTION
My IDE is complaining:

`Argument type Array is not assignable to parameter type Any`

I don't think `{Any}` is a thing in JSDoc, it's `{*}` [as far as I know](http://usejsdoc.org/tags-param.html#multiple-types-and-repeatable-parameters).
